### PR TITLE
updated to use new pipeline for clusters

### DIFF
--- a/aks/redeploying-aks-clusters.md
+++ b/aks/redeploying-aks-clusters.md
@@ -144,9 +144,9 @@ Scaling to happen just before a cluster has been removed from AGW.
 > Hi @here,
 > Due to planned upgrades of AKS, we will be upgrading the management (cftplt-intsvc) cluster at 8am, Monday 26th April. As a result of this, Jenkins will be offline during the upgrade and > unavailable for around one hour.>
 
-* Run the [Pipeline](https://dev.azure.com/hmcts/CNP/_build?definitionId=483&_a=summary) ensuring Action is set to Destroy, Cluster is set to cluster you plan to destroy and Environment is set to **PTLSBOX** before clicking on **Run**. 
+* Run the [Pipeline](https://dev.azure.com/hmcts/CNP/_build?definitionId=483&_a=summary) ensuring Action is set to Destroy, Cluster is set to cluster you plan to destroy and Environment is set to **PTL** before clicking on **Run**. 
 
-* Run the [Pipeline](https://dev.azure.com/hmcts/CNP/_build?definitionId=483&_a=summary) ensuring Action is set to Apply, Cluster is set to cluster you plan to build and Environment is set to **PTLSBOX** before clicking on **Run**. 
+* Run the [Pipeline](https://dev.azure.com/hmcts/CNP/_build?definitionId=483&_a=summary) ensuring Action is set to Apply, Cluster is set to cluster you plan to build and Environment is set to **PTL** before clicking on **Run**. 
 
 
 #### After deployment of a cluster


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-5450

### Change description ###

Updated runbook for redeploying aks clusters. Old release pipeline removed and replaced with new pipeline.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
