### PR TITLE
Remove snapshot warning about Jenkins disk

### DIFF
--- a/aks/redeploying-aks-clusters.md
+++ b/aks/redeploying-aks-clusters.md
@@ -43,8 +43,6 @@ N/A
 
 #### Before deployment of a cluster
 
-**Warning** - If you need to destroy this existing cluster then please ensure that you take a snapshot of the Jenkins disk (once the cluster has been stopped) that Sandbox Jenkins uses which runs on this cluster, the location can be obtained from [here](https://github.com/hmcts/cnp-flux-config/blob/85d61449e8633c6a975798c01e7ce155c9861c7e/apps/jenkins/jenkins/sbox-intsvc/disk.yaml#L8). Ensure that the snapshot is placed somewhere safe so that it can be used to take create a new disk. The reason for taking this snapshot is that the Jenkins disk is a persistent disk which on a recent destroy of the PTLSBOX cluster ended up also deleting that jenkin disk. As a result this meant that upon the cluster being re-deployed there was no Jenkins Disk available therefore Jenkins would not work at all until a the Jenkins disk was recreated from a previously taken snapshot.  
-
 As this environment only tends to be used by IDAM, you need to confirm with Paul Verity that the Sandbox Jenkins instance which sits on this cluster isn't being used and that he is ok with the work to go ahead. The sandbox Jenkins instance can be logged into [here](https://sandbox-build.platform.hmcts.net/).
 
 Confirm that the [cnp-plum-recipes-service](https://sandbox-build.platform.hmcts.net/job/HMCTS_Sandbox_CNP/job/cnp-plum-recipes-service/job/master/) job within Jenkins runs successfully.
@@ -171,8 +169,6 @@ Scaling to happen just before a cluster has been removed from AGW.
 - Confirm pods are back to correct numbers after revert
 
 ### Management (cftptl-intsvc)
-
-**Warning** - If you need to destroy this existing cluster then please ensure that you take a snapshot of the Jenkins disk (once the cluster has been stopped) that Sandbox Jenkins uses which runs on this cluster, the location can be obtained from [here](https://github.com/hmcts/cnp-flux-config/blob/85d61449e8633c6a975798c01e7ce155c9861c7e/apps/jenkins/jenkins/ptl-intsvc/disk.yaml#L8). Ensure that the snapshot is placed somewhere safe so that it can be used to take create a new disk. The reason for taking this snapshot is that the Jenkins disk is a persistent disk which on a recent destroy of the PTLSBOX cluster ended up also deleting that jenkin disk. As a result this meant that upon the cluster being re-deployed there was no Jenkins Disk available therefore Jenkins would not work at all until a the Jenkins disk was recreated from a previously taken snapshot.  
 
 Anything configuration wise i.e jobs, secrets, and config is stored externally from the Jenkins server, no requirement to back up the server.
 See https://github.com/hmcts/cnp-flux-config/blob/master/apps/jenkins/jenkins/ptl-intsvc/jenkins.yaml


### PR DESCRIPTION
Disks live outside of the cluster lifecycle and even if the disk is lost it doesn't matter.

I don't understand why this this warning is here