### PR TITLE
Include Civil IP changes in AAT redeploy steps

### DIFF
--- a/aks/redeploying-aks-clusters.md
+++ b/aks/redeploying-aks-clusters.md
@@ -128,6 +128,7 @@ Once swap over is fully complete then delete the older cluster,
 
 #### After deployment of a cluster
 - Add the cluster back into AGW once you have confirmed deployment has been successful. [PR example here](https://github.com/hmcts/azure-platform-terraform/pull/582)
+- Update Civil team's DNS entries to point to the active Jenkins cluster (until they switch to using platform-hmcts-net). [Update active jenkins-cluster IP value in DNS](https://github.com/hmcts/azure-private-dns/pull/428/files) and [update existing platform-hmcts-net entries](https://github.com/hmcts/azure-private-dns/pull/430/files).
 
 ### Production
 


### PR DESCRIPTION
Civil team apps crashed in AAT after our change to force https in aat-staging, so these two DNS changes were needed to reflect the current active jenkins cluster.

I think we are due to help this team migrate to platform.hmcts.net in future to avoid this switchover, as no other teams needed the change.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
