### PR TITLE
Updating AKS upgrade issues

### DIFF
--- a/source/aks/known-issues.html.md.erb
+++ b/source/aks/known-issues.html.md.erb
@@ -5,7 +5,24 @@ weight: 20
 
 # <%= current_page.data.title %>
 
-Known issues encountered during AKS cluster update or rebuild
+Known issues encountered during AKS cluster upgrade or rebuild
+
+## One or more nodes has failed to upgrade
+
+You can track the progress of the upgrade by running 
+
+```bash
+kubectl get nodes
+```
+
+Eventually all nodes will show as running the intended version, in some cases however, one or more nodes may be stuck on the old AKS version, which will block the upgrade. This happens when a given node is unable to be drained before an upgrade, the most likely cause of which is a broken application.
+
+To diagnose why a node has failed to upgrade, head to the AKS cluster in the Azure portal. Navigate to Node Pools > Linux/System/Other > Nodes > Stuck Node Name > Events. From here you will likely see a failed eviction and a reason why - after which you can troubleshoot further with the relevant team / application to unblock the node draining process. If the cluster is in a failed state, or no longer shows as updating in the portal, you will need to hit the update button again.
+
+## Quota limit reached
+
+You may encounter a quota limit during an AKS upgrade due to the provisioning of new nodes during the process. Generally, you can increase these quotas yourself [in the portal](https://portal.azure.com/#view/Microsoft_Azure_Capacity/QuotaMenuBlade/~/myQuotas) - by selecting the subscription that the AKS cluster is part of, and increasing the Compute quota to the recommended level.
+
 
 ## DaemonSet Failed Scheduling
 

--- a/source/aks/redeploying-aks-clusters.html.md.erb
+++ b/source/aks/redeploying-aks-clusters.html.md.erb
@@ -1,15 +1,15 @@
 ---
-title: Updating AKS Clusters
+title: Upgrading AKS Clusters
 weight: 30
 ---
 
 # <%= current_page.data.title %>
 
-This run book documents some tasks that we have to perform when updating any of the AKS Clusters
+This run book documents some tasks that we have to perform when upgrading any of the AKS Clusters
 
-## Cluster Order of Updating
+## Cluster Order of Upgrading
 
-This is the normal order we use when updating clusters, it does not have to exactly follow it:
+This is the normal order we use when upgrading clusters, it does not have to exactly follow it:
 
 - Sbox             - (cft-sbox-00-aks, cft-sbox-01-aks/ ss-sbox-00-aks, ss-sbox-01-aks)
 - Ptlsbox          - (cft-ptlsbox-00-aks/ ss-ptlsbox-00-aks)
@@ -89,12 +89,17 @@ We do this upgrade manually in the portal because it means we don't have terrafo
 
 <%= warning_text('The <code>kubernetes_version</code> value only takes major version values, i.e 1.25, 1.26 and so on.') %>
 
-Once the changes have been reviewed, approved and merged, run the pipeline for the environment you are updating to have terraform update the state:
+Once the changes have been reviewed, approved and merged, run the pipeline for the environment you are upgrading to have terraform update the state:
 
 - [SDS Pipeline](https://dev.azure.com/hmcts/PlatformOperations/_build?definitionId=482)
 - [CFT Pipeline](https://dev.azure.com/hmcts/PlatformOperations/_build?definitionId=766)
 
 Once completed compare the `hrs` and pods statuses with the ones you saved before the upgrade took place.
+
+<%= warning_text('Issues during an AKS Upgrade')%>
+[Troublehsooting upgrade failures](known-issues.html)
+
+If a cluster is in a failed state and you are unable to complete the cluster upgrade before the auto-shutdown of AKS clusters, please delete the AKS cluster in a failed state manually within the portal and try again the following morning. This stops active jobs and pods on the failed cluster trying to reach inactive endpoints due to the healthy cluster being shutdown.
 
 ## After upgrading of a cluster
 - Add the cluster back into the application gateway once you have confirmed the upgrade has been successful.


### PR DESCRIPTION
Update:
 -  Add some steps if the AKS upgrade fails or has issues
 - Change terminology slightly
 - Delete cluster if upgrade has failed before auto-shutdowns


![Pasted image 20230731123901](https://github.com/hmcts/ops-runbooks/assets/47995122/3ef792b9-aeb8-4cf4-9cfd-7091d5f10248)

![Pasted image 20230731124431](https://github.com/hmcts/ops-runbooks/assets/47995122/3057270e-3faa-443a-8c19-6f76c3c6eef7)



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
