### PR TITLE
Jenkins docs on downgrading a plugin

### DIFF
--- a/source/jenkins/index.html.md.erb
+++ b/source/jenkins/index.html.md.erb
@@ -45,3 +45,4 @@ Configuration is in the Jenkins base for the corresponding flux repository.
 
 - [Troubleshooting builds starting slowly](builds-starting-slowly.html)
 - [Run command on all agents](run-command-on-all-agents.html)
+- [Downgrade a plugin](plugin-downgrade.html)

--- a/source/jenkins/plugin-downgrade.html.md.erb
+++ b/source/jenkins/plugin-downgrade.html.md.erb
@@ -1,0 +1,29 @@
+---
+title: To Downgrade a Plugin on Jenkins
+weight: 30
+---
+
+# <%= current_page.data.title %>
+
+Plugin versions are managed from within [cnp-jenkins-docker](https://github.com/hmcts/cnp-jenkins-docker).
+
+Renovate checks plugin versions and [automatically upgrades them each morning](https://github.com/hmcts/cnp-jenkins-docker/blob/master/.github/renovate.json)
+
+If an issue has arisen with a new version of a plugin and it needs to be downgraded:
+
+* [Downgrade it](https://github.com/hmcts/cnp-jenkins-docker/blob/master/jenkins/plugins.txt) in the image
+* Deploy the [new image](https://github.com/hmcts/cnp-flux-config/blob/master/apps/jenkins/jenkins/jenkins-controller-version.yaml)
+
+* Jenkins may run into issues with downgrading plugins, if this is the case:
+
+Wipe the plugins folder
+```bash
+kubectl exec -it jenkins-0 -c jenkins -- rm -rf /var/jenkins_home/plugins/
+```
+Then restart Jenkins
+```bash
+kubectl delete pod jenkins-0
+```
+
+* Make the maintainers of the plugin aware of the issue
+* Freeze renovate for that particular plugin (add to `ignoreDeps`)

--- a/source/jenkins/plugin-downgrade.html.md.erb
+++ b/source/jenkins/plugin-downgrade.html.md.erb
@@ -1,5 +1,5 @@
 ---
-title: To Downgrade a Plugin on Jenkins
+title: How to downgrade a Jenkins plugin
 weight: 30
 ---
 
@@ -12,9 +12,9 @@ Renovate checks plugin versions and [automatically upgrades them each morning](h
 If an issue has arisen with a new version of a plugin and it needs to be downgraded:
 
 * [Downgrade it](https://github.com/hmcts/cnp-jenkins-docker/blob/master/jenkins/plugins.txt) in the image
-* Deploy the [new image](https://github.com/hmcts/cnp-flux-config/blob/master/apps/jenkins/jenkins/jenkins-controller-version.yaml)
+* Deploy the [new image on CFT](https://github.com/hmcts/cnp-flux-config/blob/master/apps/jenkins/jenkins/jenkins-controller-version.yaml) and [on SDS](https://github.com/hmcts/sds-flux-config/blob/master/apps/jenkins/jenkins/jenkins-controller-version.yaml)
 
-* Jenkins may run into issues with downgrading plugins, if this is the case:
+* Jenkins may run into issues when downgrading plugins, if this is the case:
 
 Wipe the plugins folder
 ```bash
@@ -26,4 +26,4 @@ kubectl delete pod jenkins-0
 ```
 
 * Make the maintainers of the plugin aware of the issue
-* Freeze renovate for that particular plugin (add to `ignoreDeps`)
+* Temporarily freeze renovate for that particular plugin (add to `ignoreDeps`)


### PR DESCRIPTION
Describe steps needed in downgrading a plugin

To cover steps in case a plugin requires a downgrade again in future - related to lockable-resources plugin recently (occasionally needed)
