### PR TITLE
dtspo-16871: Add runbook for dns node cache image

### DIFF
--- a/source/aks/patching-aks-apps.html.md.erb
+++ b/source/aks/patching-aks-apps.html.md.erb
@@ -172,5 +172,6 @@ AAD Pod Identity has been deprecated hence there is not going to be further patc
 - [KEDA](patching-keda-example.html)
 - [Dynatrace Operator](patching-dynatrace.html)
 - [Flux](patching-flux-example.html)
+- [dns-node-cache](patching-flux-example.html)
 - [pact-broker](patching-pact-broker-example.html)
 - [kured](patching-kured-example.html)

--- a/source/aks/patching-dns-node-cache.html.md.erb
+++ b/source/aks/patching-dns-node-cache.html.md.erb
@@ -1,0 +1,17 @@
+---
+title: DNS Node Cache Patching
+weight: 30
+last_reviewed_on: 2024-02-26
+review_in: 12 months
+---
+
+# <%= current_page.data.title %>
+
+This document covers how to check and patch the DNS node cache image.
+The image should be updated automatically by renovate, but if it is not, you can manually update the image in the [nodelocaldns.yaml](https://github.com/hmcts/cnp-flux-config/blob/master/apps/kube-system/nodelocaldns/nodelocaldns.yaml#L132) file in the [cnp flux config repo](https://github.com/hmcts/cnp-flux-config).
+
+## Patching
+First, check what the latest version of [DNS Node Cache Releases](https://github.com/kubernetes/kubernetes/blob/98bd90fbe279f9083db92c51badce424d6d8b1c1/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml#L141) is.
+
+Then create a PR in the [cnp flux config repo](https://github.com/hmcts/cnp-flux-config) to bump up the [DNS node cache image](https://github.com/hmcts/cnp-flux-config/blob/master/apps/kube-system/nodelocaldns/nodelocaldns.yaml#L132) version
+


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-16871


### Change description ###
Create runbook info on how to check for a new version of the dns node cache image.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
