### PR TITLE
Enable external link checking again

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,7 +10,6 @@ task :check_urls do
             :check_external_hash => false,
             :ignore_missing_alt => true,
             :ignore_status_codes => [0, 401, 403],
-            :disable_external => true,
             :ignore_urls =>  [
                 # Ignore pulls/branches as these do not translate to raw content
                 %r{github\.com/hmcts/(?=.*(?:pull|tree|commit))},


### PR DESCRIPTION
Seems like an accidental change from https://github.com/hmcts/ops-runbooks/pull/258/files that wasn't in the original