### PR TITLE
Re-add ext. links, fix broken ones

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,8 +17,7 @@ task :check_urls do
                 %r{.*.platform.hmcts.net},
                 # This is a url that's generated each time we build the html by tech-docs-gem but does not exist
                 %r{https://github.com/hmcts/ops-runbooks/blob/master/source/search/index.html}
-            ],
-            :new_files_ignore => true
+            ]
         })
 
     token = ENV.fetch('GH_TOKEN', nil)

--- a/Rakefile
+++ b/Rakefile
@@ -10,10 +10,11 @@ task :check_urls do
             :check_external_hash => false,
             :ignore_missing_alt => true,
             :ignore_status_codes => [0, 401, 403],
-            :disable_external => true,
             :ignore_urls =>  [
                 # Ignore pulls/branches as these do not translate to raw content
                 %r{github\.com/hmcts/(?=.*(?:pull|tree|commit))},
+                # App health should not affect runbook PRs
+                %r{.*.platform.hmcts.net},
                 # This is a url that's generated each time we build the html by tech-docs-gem but does not exist
                 %r{https://github.com/hmcts/ops-runbooks/blob/master/source/search/index.html}
             ],

--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ task :check_urls do
         {
             :check_external_hash => false,
             :ignore_missing_alt => true,
-            :ignore_status_codes => [0, 401, 403],
+            :ignore_status_codes => [401, 403],
             :ignore_urls =>  [
                 # Ignore pulls/branches as these do not translate to raw content
                 %r{github\.com/hmcts/(?=.*(?:pull|tree|commit))},

--- a/source/Services/apim-migration.html.md.erb
+++ b/source/Services/apim-migration.html.md.erb
@@ -34,7 +34,7 @@ Update hub-panorama-terraform with the new private IP. [hub-panoram-terraform](h
 
 ### Updating DNS
 
-Update the private DNS address with new private IP  [Private DNS](https://github.com/hmcts/azure-private-dns/blob/master/environments)
+Update the private DNS address with new private IP  [Private DNS](https://github.com/hmcts/azure-private-dns/tree/master/environments)
 
 Clean up temporary resources
 

--- a/source/aks/patching-artifactory.html.md.erb
+++ b/source/aks/patching-artifactory.html.md.erb
@@ -143,7 +143,7 @@ patchesStrategicMerge:-../../artifactory/artifactory-sbox.yaml
 
 Troubleshooting Steps:
 
-To resolve namespace issues in ["chart-neuvector"] (https://hmcts.github.io/ops-runbooks/aks/updating-neuvector-policies.html). We had specific issues with neuvector which should be resolved and the details can be found in the linked page.
+To resolve namespace issues in ["chart-neuvector"] (https://hmcts.github.io/ops-runbooks/neuvector/updating-neuvector-policies.html). We had specific issues with neuvector which should be resolved and the details can be found in the linked page.
 
 Related Links:
 

--- a/source/aks/patching-artifactory.html.md.erb
+++ b/source/aks/patching-artifactory.html.md.erb
@@ -73,8 +73,6 @@ This command provides detailed information about the desired pods, confirming th
 
 • Create a new file named "artifactory-sbox.yaml" with the provided code snippet
 
-test this please: [oops](https://broken-link-oops.com)
-
 ```command
 apiVersion: apps/v1
 kind: StatefulSet

--- a/source/aks/patching-artifactory.html.md.erb
+++ b/source/aks/patching-artifactory.html.md.erb
@@ -73,6 +73,8 @@ This command provides detailed information about the desired pods, confirming th
 
 • Create a new file named "artifactory-sbox.yaml" with the provided code snippet
 
+test this please: [oops](https://broken-link-oops.com)
+
 ```command
 apiVersion: apps/v1
 kind: StatefulSet


### PR DESCRIPTION
I think https://github.com/hmcts/ops-runbooks/compare/fix-broken-links?expand=1#diff-ee98e028c59b193d58fde56ab4daf54d43c486ae674e63d50ddf300b07943e0fL13 was accidentally added during https://github.com/hmcts/ops-runbooks/pull/258/files that wasn't in the original

Also fixes two broken links

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
