### PR TITLE
DTSPO-22524 adding --version flag to flux install command for Flux patching

### DIFF
--- a/source/aks/patching-flux-example.html.md.erb
+++ b/source/aks/patching-flux-example.html.md.erb
@@ -32,7 +32,7 @@ The generic process can be found on the [Flux website](https://fluxcd.io/flux/in
 
 Make sure to clone the flux repos and enter them on your terminal by running `cd cnp-flux-config` or `cd sds-flux-config`.
 
-The specific command we need to target an environment, it is recommended to add the `--version` flag at the end as flux will default to your local configutation. e.g, sandbox, is:
+The specific command we need to target an environment, it is recommended to add the `--version` flag at the end as flux will default to your local configuration. e.g, sandbox, is:
 
 ```
 flux install --export > apps/flux-system/sbox/base/gotk-components.yaml --version v2.4.0

--- a/source/aks/patching-flux-example.html.md.erb
+++ b/source/aks/patching-flux-example.html.md.erb
@@ -32,10 +32,10 @@ The generic process can be found on the [Flux website](https://fluxcd.io/flux/in
 
 Make sure to clone the flux repos and enter them on your terminal by running `cd cnp-flux-config` or `cd sds-flux-config`.
 
-The specific command we need to target an environment, e.g, sandbox, is:
+The specific command we need to target an environment, it is recommended to add the `--version` flag at the end as flux will default to your local configutation. e.g, sandbox, is:
 
 ```
-flux install --export > apps/flux-system/sbox/base/gotk-components.yaml
+flux install --export > apps/flux-system/sbox/base/gotk-components.yaml --version v2.4.0
 ```
 
 This command will generate a file containing the latest versions of all the flux components.
@@ -117,7 +117,3 @@ Below is a step by step on how to upgrade flux when there are API changes includ
 4. Test again using commands above.
 5. Upgrade API versions e.g. [HelmRelease](https://github.com/hmcts/sds-flux-config/pull/4133) and [ImageRepository](https://github.com/hmcts/sds-flux-config/pull/4134)
 6. Test all is still working after the upgrade. **NOTE:** You can also apply the API changes only to Plum/Toffee initially to test, before applying to other apps.
-
-
-
-


### PR DESCRIPTION
### Jira link

DTSPO-22524

### Change description

--version flag to flux install command for Flux patching

Without this flag, flux will default to your local version.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
