### PR TITLE
DTSPO-26181 - add crime cert info

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -26,6 +26,7 @@ datacentre
 Datlassian
 DBfor
 deevanapalli
+DEVJUMPL
 devrot
 dockerfiles
 dsl
@@ -39,6 +40,7 @@ geolocationfile
 GEOLOCATIONUPDATES
 Glust
 gluster
+Hashicorp
 IMZ
 Jacomb
 Jenkinsfiles
@@ -55,12 +57,18 @@ Manan
 mdv
 MDVADMVPNHA
 Miniport
+mnl
 Moj
+mpd
 myregistry
 nodelocaldns
 NONLINE
+noout
 NSGs
+oidc
+onlineplea
 paramatised
+pki
 pmd
 prd
 PRDATL
@@ -74,6 +82,7 @@ recoverypoint
 regitries
 Resouce
 Rns
+ruleset
 ruxit
 SBZ
 sku
@@ -99,11 +108,6 @@ utilisation
 Virtualbox
 virtualwan
 VNETs
+wafcc
 wsdl
 XXXX
-ruleset
-pmd
-DEVJUMPL
-mpd
-onlineplea
-wafcc

--- a/source/Certificates/hashicorp-vault.html.md.erb
+++ b/source/Certificates/hashicorp-vault.html.md.erb
@@ -1,0 +1,51 @@
+---
+title: Requesting SSL Certificates via Hashicorp Vault
+last_reviewed_on: 2025-07-08
+review_in: 12 months
+weight: 20
+---
+
+# <%= current_page.data.title %>
+
+Follow the [confluence document](https://tools.hmcts.net/confluence/display/DTSPO/Hashicorp+Vault+-+How+to+use+and+interact+with+Vault) to get connected to vault.
+
+For this, you may require the root token instead of oidc, depending on what permission level you have.
+
+You can find the token in one of the keyvaults.
+
+Once you are connected to the vault using the instructions above, you can request the certificate.
+
+```
+vault write pki_mnl_int/issue/mnl-nl-cjscp-org-uk common_name="<full domain name>" ttl="1h"
+```
+
+For example:
+
+```
+vault write pki_mnl_int/issue/mnl-nl-cjscp-org-uk common_name="darts-gateway.mnl.nl.cjscp.org.uk" ttl="1h"
+```
+
+The cert will be generated and saved in the vault.
+
+The output of the command will give you a fingerprint which you can use to verify the domain name using:
+
+```
+vault read -format=json pki_mnl_int/cert/<fingerprint> | jq -r '.data.certificate' | openssl x509 -noout -subject -ext subjectAltName
+```
+
+This will give you something like this:
+
+```
+subject=CN=darts-gateway.mnl.nl.cjscp.org.uk
+X509v3 Subject Alternative Name: 
+    DNS:darts-gateway.mnl.nl.cjscp.org.uk
+```
+
+## Adding the certificate to the application gateway for Crime
+
+An integration has been configured to copy the cert to Azure Keyvault to use with application gateway.
+
+Add your certificate to the config using the [correct format](https://github.com/hmcts/cpp-terraform-azurerm-imz/blob/c76bdd3f13522e846b2b6c339ba079fd2e112ce4/vars/mdv.tfvars#L562-L565).
+
+And specify the certificate in the [listener settings](https://github.com/hmcts/cpp-terraform-azurerm-imz/blob/c76bdd3f13522e846b2b6c339ba079fd2e112ce4/vars/mdv.tfvars#L550).
+

--- a/source/Certificates/index.html.md.erb
+++ b/source/Certificates/index.html.md.erb
@@ -18,3 +18,4 @@ This guide describes the process for creating an SSL certificate using Let’s E
 - [Add the ACME Function App to a new subscription](newacme.html)
 - [CRIME frontend WAFs](https://tools.hmcts.net/confluence/display/HSS/How+to+renew+certificates+for+a+SSL-Based+Service+on+the+frontend+WAFs)
 - [XHIBIT WAF Certificates](https://tools.hmcts.net/confluence/display/DTSPO/XHIBIT+WAF+Certificates)
+- [Requesting SSL Certificates via Hashicorp Vault](hashicorp-vault.html)


### PR DESCRIPTION
### Jira link

See [DTSPO-26181](https://tools.hmcts.net/jira/browse/DTSPO-26181)

### Change description

Add some guidance on how to request a certificate via hashicorp vault and use it with application gateway

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
