### PR TITLE
Ignoring 429 error code when checking links

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ task :check_urls do
         {
             :check_external_hash => false,
             :ignore_missing_alt => true,
-            :ignore_status_codes => [0, 401, 403],
+            :ignore_status_codes => [0, 401, 403, 429],
             :ignore_urls =>  [
                 # Ignore pulls/branches as these do not translate to raw content
                 %r{github\.com/hmcts/(?=.*(?:pull|tree|commit))},


### PR DESCRIPTION
To fix this - 
https://github.com/hmcts/ops-runbooks/actions/runs/17672637615/job/50227563035 

We do not have control on the external links which rate limiting, hence ignoring it.
