### PR TITLE
docs: add language support runbook for platform team

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -59,10 +59,12 @@ Datlassian
 DBfor
 dbsetup
 dde
+debian
 deevanapalli
 DEVJUMPL
 devrot
 dgwzf
+distroless
 dnat
 dockerfiles
 dsl
@@ -78,6 +80,7 @@ Ente
 ENVCCM
 Eyetan
 failedjobshistorylimit
+fastapi
 fba
 fbf
 federatedidentitycredential
@@ -116,7 +119,6 @@ jira
 JMES
 journalctl
 kalyan
-keyfile
 kiali
 KQL
 kubctl
@@ -163,7 +165,6 @@ onmicrosoft
 openvpn
 overriden
 paramatised
-pcs
 peerings
 pki
 plumsi
@@ -252,8 +253,6 @@ vvv
 wafcc
 wildfly
 wrkagentpool
-wsdl
 xpack
 XXXX
 zlf
-zshrc

--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,9 @@ task :check_urls do
                 # This is a url that's generated each time we build the html by tech-docs-gem but does not exist
                 %r{https://github.com/hmcts/ops-runbooks/blob/master/source/search/index.html},
                 # This handles new files that haven't been merged to master branch yet for this repo in a PR
-                %r{(?=.*ops-runbooks)(?=.*github)}
+                %r{(?=.*ops-runbooks)(?=.*github)},
+                # Staging environment, not reliably accessible
+                'https://crimeportal.staging.apps.hmcts.net'
             ]
         })
 

--- a/source/language-support/index.html.md.erb
+++ b/source/language-support/index.html.md.erb
@@ -9,7 +9,7 @@ weight: 230
 
 This guide covers how to add first-class support for a new programming language on the HMCTS platform. Follow the checklist below in order — each step links to its reference section.
 
-Use [Python support](https://github.com/hmcts/cnp-python-base) as the reference implementation throughout. The repositories created for Python are linked in each section as concrete examples.
+We will reference recent work to add Python support to the platform, but the same steps apply to any language.
 
 ## Checklist
 
@@ -39,7 +39,9 @@ Two things to add:
   targetImage: 'imported/distroless/python3'
 ```
 
-**B. Add a cache rule** — add an entry to [`acr-repositories.yaml`](https://github.com/hmcts/acr-base-importer/blob/master/acr-repositories.yaml). Cache rules allow teams to pull the image transparently from `hmctsprod` without hitting the upstream registry directly.
+**B. Add a cache rule (optional)** — depending on the language, teams may need additional upstream images available in ACR beyond the base image. For example, Python requires a multi-stage Docker build where the build stage uses a full Python image (with uv/pip and build tooling) to install dependencies, before copying the result into the distroless runtime image. A cache rule gives teams access to that builder image from `hmctsprod` rather than hitting the upstream registry directly.
+
+If the language runtime image is self-contained and no additional images are needed at build time, this step can be skipped. Add entries to [`acr-repositories.yaml`](https://github.com/hmcts/acr-base-importer/blob/master/acr-repositories.yaml) for any additional images that are required.
 
 See the [acr-base-importer README](https://github.com/hmcts/acr-base-importer#readme) for the full configuration reference.
 

--- a/source/language-support/index.html.md.erb
+++ b/source/language-support/index.html.md.erb
@@ -1,0 +1,204 @@
+---
+title: Adding a new language to the platform
+last_reviewed_on: 2026-06-23
+review_in: 12 months
+weight: 230
+---
+
+# <%= current_page.data.title %>
+
+This guide covers how to add first-class support for a new programming language on the HMCTS platform. Follow the checklist below in order — each step links to its reference section.
+
+Use [Python support](https://github.com/hmcts/cnp-python-base) as the reference implementation throughout. The repositories created for Python are linked in each section as concrete examples.
+
+## Checklist
+
+1. [ ] [Import the upstream base image into ACR](#1-import-the-upstream-base-image)
+2. [ ] [Create the base Docker image](#2-create-the-base-docker-image)
+3. [ ] [Create the base Helm chart](#3-create-the-base-helm-chart)
+4. [ ] [Create service templates](#4-create-service-templates)
+5. [ ] [Update the Jenkins pipeline](#5-update-the-jenkins-pipeline)
+6. [ ] [Create a test application](#6-create-a-test-application)
+7. [ ] [Deploy to AKS via Flux](#7-deploy-to-aks-via-flux)
+8. [ ] [Write documentation and the golden path](#8-write-documentation-and-the-golden-path)
+
+---
+
+## 1. Import the upstream base image
+
+Before building an HMCTS base image you need the upstream image available in our ACR. This is managed by [acr-base-importer](https://github.com/hmcts/acr-base-importer).
+
+Two things to add:
+
+**A. Import the image** — add an entry to `baseImagestoImport` in [`trivy-scan-import.yml`](https://github.com/hmcts/acr-base-importer/blob/master/trivy-scan-import.yml). This imports the image into `hmctsprod` (and optionally `hmctssbox`) on a daily schedule, scanning for critical vulnerabilities before import.
+
+```yaml
+- baseRegistry: 'gcr.io'
+  baseImage: 'distroless/python3-debian13'
+  baseTag: 'latest'
+  targetImage: 'imported/distroless/python3'
+```
+
+**B. Add a cache rule** — add an entry to [`acr-repositories.yaml`](https://github.com/hmcts/acr-base-importer/blob/master/acr-repositories.yaml). Cache rules allow teams to pull the image transparently from `hmctsprod` without hitting the upstream registry directly.
+
+See the [acr-base-importer README](https://github.com/hmcts/acr-base-importer#readme) for the full configuration reference.
+
+---
+
+## 2. Create the base Docker image
+
+Create a new repository named `cnp-{language}-base` in the `hmcts` GitHub organisation.
+
+The base image sits between the upstream distroless/runtime image and application Dockerfiles. Its responsibilities are:
+
+- Installing the language runtime and package manager
+- Pre-wiring observability tooling (Azure Application Insights via OpenTelemetry)
+- Providing a consistent, security-scanned foundation for all services using that language
+
+The application Dockerfile then extends the base image with only application-specific layers.
+
+**Reference:** [cnp-python-base](https://github.com/hmcts/cnp-python-base) — includes the build pipeline, Application Insights wiring, and a `README` documenting the environment variables available to applications.
+
+---
+
+## 3. Create the base Helm chart
+
+Create a new repository named `chart-{language}` in the `hmcts` GitHub organisation.
+
+The base Helm chart provides the standard Kubernetes deployment configuration for services written in that language. It should cover:
+
+- Deployment, Service, and Ingress resources
+- Readiness and liveness probe paths (e.g. `/health/readiness`, `/health/liveness`)
+- Key Vault secret mounting via the CSI driver
+- Environment variable configuration
+- HPA (Horizontal Pod Autoscaler) configuration
+- PostgreSQL sidecar support (if applicable)
+
+The chart is published to [hmcts-charts](https://github.com/hmcts/hmcts-charts) via the release pipeline so it can be consumed as a Helm dependency by application charts.
+
+**Reference:** [chart-python](https://github.com/hmcts/chart-python) — see its README for the full set of configurable values.
+
+---
+
+## 4. Create service templates
+
+Two templates are needed: one for GitHub and one for Backstage. Both scaffold a new service that is immediately pipeline-compatible.
+
+### GitHub template
+
+Create a repository named `{framework}-template-github` (e.g. `fastapi-template-github`).
+
+The template must include:
+
+- Application scaffold with the framework installed and a working entry point
+- `GET /health`, `GET /health/readiness`, `GET /health/liveness` endpoints
+- `Jenkinsfile_CNP`, `Jenkinsfile_nightly`, `Jenkinsfile_parameterized`
+- `sonar-project.properties`
+- Helm chart in `charts/` using the base Helm chart
+- `values.preview.template.yaml` and `values.aat.template.yaml`
+- GitHub Actions CI workflow (lint, test, coverage)
+- `.python-version` or equivalent runtime version file
+- Lock file committed (e.g. `uv.lock`)
+- `README.md` covering local setup, testing, dependencies, security scanning, and Application Insights
+
+**Reference:** [fastapi-template-github](https://github.com/hmcts/fastapi-template-github)
+
+### Backstage template
+
+Create a repository named `{framework}-template-backstage` (e.g. `fastapi-template-backstage`). This wraps the GitHub template with Backstage scaffolding so it appears in the HMCTS software catalogue under "Create".
+
+The `skeleton/` directory mirrors the GitHub template structure, with Backstage template variables (e.g. `${{ values.product }}`, `${{ values.component }}`) substituted throughout.
+
+**Reference:** [fastapi-template-backstage](https://github.com/hmcts/fastapi-template-backstage)
+
+---
+
+## 5. Update the Jenkins pipeline
+
+The common pipeline ([cnp-jenkins-library](https://github.com/hmcts/cnp-jenkins-library)) needs four changes to support a new language.
+
+### Builder class
+
+Create `src/uk/gov/hmcts/contino/{Language}Builder.groovy` extending `AbstractBuilder`. Implement at minimum:
+
+| Method | Purpose |
+|---|---|
+| `build()` | Install dependencies |
+| `test()` | Run unit tests with coverage |
+| `securityCheck()` | Run dependency vulnerability audit, archive report, fail on findings |
+| `sonarScan()` | Run SonarCloud scanner |
+| `smokeTest()` | Run smoke tests post-deploy |
+| `functionalTest()` | Run functional tests post-deploy |
+
+**Reference:** [`PythonBuilder.groovy`](https://github.com/hmcts/cnp-jenkins-library/blob/master/src/uk/gov/hmcts/contino/PythonBuilder.groovy)
+
+### PipelineType class
+
+Create `src/uk/gov/hmcts/contino/{Language}PipelineType.groovy`. This wires the Builder to the pipeline and declares the language identifier.
+
+**Reference:** [`PythonPipelineType.groovy`](https://github.com/hmcts/cnp-jenkins-library/blob/master/src/uk/gov/hmcts/contino/PythonPipelineType.groovy)
+
+### Register in pipeline entry points
+
+Add an import and an entry to the `pipelineTypes` map in all three pipeline files:
+
+- `vars/withPipeline.groovy`
+- `vars/withParameterizedPipeline.groovy`
+- `vars/withNightlyPipeline.groovy`
+
+```groovy
+import uk.gov.hmcts.contino.PythonPipelineType
+
+// in pipelineTypes map:
+python: { new PythonPipelineType(this, product, component) }
+```
+
+### Tests
+
+Add a corresponding test class at `test/uk/gov/hmcts/contino/{Language}BuilderTest.groovy`. All existing tests must continue to pass.
+
+Run the test suite locally before raising a PR:
+
+```bash
+./gradlew test
+```
+
+---
+
+## 6. Create a test application
+
+Before announcing support, validate the full pipeline end-to-end with a real application in the `hmcts` GitHub organisation.
+
+Use the GitHub template to scaffold the app. The test application should exercise:
+
+- The full Jenkins pipeline (build, test, Sonar, security check, Docker build, preview deploy)
+- Smoke and functional tests running post-deploy
+- The base Helm chart values files
+- Application Insights (if wired in the base image)
+
+**Reference:** [cnp-plum-fastapi-backend](https://github.com/hmcts/cnp-plum-fastapi-backend)
+
+---
+
+## 7. Deploy to AKS via Flux
+
+Once the test application is working in preview, register it in the appropriate Flux config repo so it is deployed and managed across all environments.
+
+- **CFT clusters:** [cnp-flux-config](https://github.com/hmcts/cnp-flux-config) — see the [app deployment guide](https://github.com/hmcts/cnp-flux-config/blob/master/docs/app-deployment-v2.md)
+- **SDS clusters:** [sds-flux-config](https://github.com/hmcts/sds-flux-config) — follows the same process
+
+---
+
+## 8. Write documentation and the golden path
+
+Once support is validated end-to-end, create the developer-facing documentation and register the Backstage template.
+
+### Developer documentation
+
+Add a page to [hmcts.github.io](https://github.com/hmcts/hmcts.github.io) under `source/cloud-native-platform/new-component/`. Follow the same structure as the existing developer docs.
+
+**Reference:** [Python services guide](https://hmcts.github.io/cloud-native-platform/new-component/python.html) and its [source](https://github.com/hmcts/hmcts.github.io/blob/main/source/cloud-native-platform/new-component/python.html.md.erb).
+
+### Backstage catalogue
+
+Register the Backstage template in the HMCTS software catalogue so developers can self-serve from the "Create" page. See the Backstage admin documentation for how to register a new template.

--- a/source/language-support/index.html.md.erb
+++ b/source/language-support/index.html.md.erb
@@ -39,9 +39,14 @@ Two things to add:
   targetImage: 'imported/distroless/python3'
 ```
 
-**B. Add a cache rule (optional)** — depending on the language, teams may need additional upstream images available in ACR beyond the base image. For example, Python requires a multi-stage Docker build where the build stage uses a full Python image (with uv/pip and build tooling) to install dependencies, before copying the result into the distroless runtime image. A cache rule gives teams access to that builder image from `hmctsprod` rather than hitting the upstream registry directly.
+**B. Import any additional images (optional)** — depending on the language, teams may need additional upstream images available in ACR beyond the base image. For example, Python requires a multi-stage Docker build where the build stage uses a full Python image (with uv/pip and build tooling) to install dependencies, before copying the result into the distroless runtime image.
 
-If the language runtime image is self-contained and no additional images are needed at build time, this step can be skipped. Add entries to [`acr-repositories.yaml`](https://github.com/hmcts/acr-base-importer/blob/master/acr-repositories.yaml) for any additional images that are required.
+If the language runtime image is self-contained and no additional images are needed at build time, this step can be skipped.
+
+How an additional image is made available depends on its source registry:
+
+- **`docker.io` images** — create a cache rule in [`acr-repositories.yaml`](https://github.com/hmcts/acr-base-importer/blob/master/acr-repositories.yaml). This proxies pulls through `hmctsprod` rather than hitting Docker Hub directly.
+- **`ghcr.io` images** — add an import entry to [`trivy-scan-import.yml`](https://github.com/hmcts/acr-base-importer/blob/master/trivy-scan-import.yml), the same way as the base image in step A.
 
 See the [acr-base-importer README](https://github.com/hmcts/acr-base-importer#readme) for the full configuration reference.
 

--- a/source/language-support/index.html.md.erb
+++ b/source/language-support/index.html.md.erb
@@ -115,6 +115,10 @@ The `skeleton/` directory mirrors the GitHub template structure, with Backstage 
 
 **Reference:** [fastapi-template-backstage](https://github.com/hmcts/fastapi-template-backstage)
 
+### Registering in the Backstage catalogue
+
+Once the template repository is created, register it in [backstage-portal](https://github.com/hmcts/backstage-portal) so it appears under "Create" in the software catalogue. Templates are registered in [`app-config.production.yaml`](https://github.com/hmcts/backstage-portal/blob/3374063fddbeaf52de7aa2288fac636507d7cf76/app-config.production.yaml#L150) — add an entry pointing to the `template.yaml` in your new Backstage template repository.
+
 ---
 
 ## 5. Update the Jenkins pipeline
@@ -173,7 +177,7 @@ Run the test suite locally before raising a PR:
 
 Before announcing support, validate the full pipeline end-to-end with a real application in the `hmcts` GitHub organisation.
 
-Use the GitHub template to scaffold the app. The test application should exercise:
+Use the GitHub or Backstage template to scaffold the app. The test application should exercise:
 
 - The full Jenkins pipeline (build, test, Sonar, security check, Docker build, preview deploy)
 - Smoke and functional tests running post-deploy
@@ -195,14 +199,10 @@ Once the test application is working in preview, register it in the appropriate 
 
 ## 8. Write documentation and the golden path
 
-Once support is validated end-to-end, create the developer-facing documentation and register the Backstage template.
+Once support is validated end-to-end, create the developer-facing documentation.
 
 ### Developer documentation
 
 Add a page to [hmcts.github.io](https://github.com/hmcts/hmcts.github.io) under `source/cloud-native-platform/new-component/`. Follow the same structure as the existing developer docs.
 
 **Reference:** [Python services guide](https://hmcts.github.io/cloud-native-platform/new-component/python.html) and its [source](https://github.com/hmcts/hmcts.github.io/blob/main/source/cloud-native-platform/new-component/python.html.md.erb).
-
-### Backstage catalogue
-
-Register the Backstage template in the HMCTS software catalogue so developers can self-serve from the "Create" page. See the Backstage admin documentation for how to register a new template.

--- a/source/language-support/index.html.md.erb
+++ b/source/language-support/index.html.md.erb
@@ -67,7 +67,9 @@ The application Dockerfile then extends the base image with only application-spe
 
 Create a new repository named `chart-{language}` in the `hmcts` GitHub organisation.
 
-The base Helm chart provides the standard Kubernetes deployment configuration for services written in that language. It should cover:
+The base Helm chart provides the standard Kubernetes deployment configuration for services written in that language. It extends [chart-library](https://github.com/hmcts/chart-library), which provides the common HMCTS Helm templates (Deployment, Service, Ingress, etc.). The language-specific chart adds sensible defaults on top — things like the application port, health probe paths, and any language-specific sidecar configuration.
+
+It should cover:
 
 - Deployment, Service, and Ingress resources
 - Readiness and liveness probe paths (e.g. `/health/readiness`, `/health/liveness`)


### PR DESCRIPTION
Adds a new runbook under `source/language-support/` for platform engineers adding support for a new programming language.

Covers all 8 steps in order with a top-level checklist:
1. Import upstream base image into ACR (acr-base-importer)
2. Create the base Docker image
3. Create the base Helm chart (extending chart-library)
4. Create service templates (GitHub + Backstage, including catalogue registration)
5. Update the Jenkins pipeline (Builder, PipelineType, pipeline entry points, tests)
6. Create a test application
7. Deploy to AKS via Flux
8. Write developer documentation

Each section references the Python implementation as a concrete example.