### PR TITLE
Fx references to gitpod in contribution guide

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -42,6 +42,7 @@ CJSC
 clusterrole
 clusterrolebinding
 coderepo
+Codespaces
 configmap
 containerised
 coreutils
@@ -164,6 +165,7 @@ onlineplea
 onmicrosoft
 openvpn
 overriden
+panupv
 paramatised
 peerings
 pki
@@ -231,6 +233,7 @@ switchovers
 sysagentpool
 tblk
 Tenables
+tgz
 themisgatewayapi
 thw
 timeframe
@@ -256,5 +259,3 @@ wrkagentpool
 xpack
 XXXX
 zlf
-panupv
-tgz

--- a/source/Contribution-Guide/index.html.md.erb
+++ b/source/Contribution-Guide/index.html.md.erb
@@ -32,8 +32,8 @@ Our Operations Runbooks serve as the single source of truth for operational proc
 
 ## Contributing (using GitHub Codespaces)
 
-HMCTS way used Gitpod, browser based IDE where ruby/ruby dependencies can be auto-installed from dependency file. 
-Contributors can open the repo in Gitpod and easily make changes and recompile the static site without having to worry about managing their ruby version/dependencies on the local machine
+HMCTS way used GitHub Codespaces, browser based IDE where ruby/ruby dependencies can be auto-installed from dependency file. 
+Contributors can open the repo in GitHub Codespaces and easily make changes and recompile the static site without having to worry about managing their ruby version/dependencies on the local machine
 
 To get started with GitHub Codespaces:
 

--- a/source/Contribution-Guide/index.html.md.erb
+++ b/source/Contribution-Guide/index.html.md.erb
@@ -27,17 +27,17 @@ Our Operations Runbooks serve as the single source of truth for operational proc
 
 1. Familiarise yourself with the existing documentation structure.
 2. Identify areas where you can contribute or improve existing content.
-3. Set up your development environment using GitPod (see Contributing section).
+3. Set up your development environment using GitHub Codespaces (see Contributing section).
 4. Make your changes and submit a pull request for review.
 
-## Contributing (using GitPod)
+## Contributing (using GitHub Codespaces)
 
 HMCTS way used Gitpod, browser based IDE where ruby/ruby dependencies can be auto-installed from dependency file. 
 Contributors can open the repo in Gitpod and easily make changes and recompile the static site without having to worry about managing their ruby version/dependencies on the local machine
 
-To get started with GitPod:
+To get started with GitHub Codespaces:
 
-1. [Open in Gitpod](https://gitpod.io/#https://github.com/hmcts/ops-runbooks)
+1. [Open in GitHub Codespaces](https://codespaces.new/hmcts/ops-runbooks)
 2. Make your desired changes to the documentation
 3. Preview your changes using the built-in server
 4. Commit and push your changes to create a pull request


### PR DESCRIPTION
### Change description

Noticed this old reference while prepping for show and tell
Updating old reference to gitpod to codespaces

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
